### PR TITLE
fix subscripts with greek letters

### DIFF
--- a/format.go
+++ b/format.go
@@ -90,7 +90,7 @@ func init() {
 
 	// Build regular expressions.
 	supregexp = regexp.MustCompile(`(\b[A-Za-z0-9]|[)\pL\pS^A-Za-z0-9])\^(\d+|\{` + charclass(superclass) + `+\}|` + charclass(superclass) + `\s)`)
-	subregexp = regexp.MustCompile(`(\b[A-Za-z]|\pS)_(\d+\b|\{` + charclass(subclass) + `+\})`)
+	subregexp = regexp.MustCompile(`(\b[A-Za-z]|\pS|\p{Greek})_(\d+\b|\{` + charclass(subclass) + `+\})`)
 }
 
 // charclass builds a regular expression character class from a list of runes.

--- a/format_test.go
+++ b/format_test.go
@@ -73,6 +73,16 @@ func TestFormula(t *testing.T) {
 			Input:  `\zeta(s) = \sum 1/n^{s}`,
 			Expect: `ζ(s) = ∑ 1/nˢ`,
 		},
+		{
+			Name:   "issue_14_eta_sub_2",
+			Input:  `\eta_2`,
+			Expect: "η₂",
+		},
+		{
+			Name:   "issue_14_eta_sup_2",
+			Input:  `\eta^2`,
+			Expect: "η²",
+		},
 	}
 	for _, c := range cases {
 		c := c // scopelint


### PR DESCRIPTION
Currently the regular expression for subscripts excludes greek letters, leading to the bug described in #14. This PR extends the regular expression.